### PR TITLE
Fix GPS warns

### DIFF
--- a/av_gps_launch/CHANGELOG.rst
+++ b/av_gps_launch/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package av_gps_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update parameters
+  - Set use_binary_message to false to avoid ASCII parsing warnings
+  - Set publish_imu_messages to false as IMU is not integrated on
+  current GNSS
+  - Define wayt_for_sync to wait for both BESTPOS and BESTVEL messages
+  to arrive before publishing gps_msgs/GPSFix
+* Contributors: Hector Cruz
+
 1.3.0 (2024-12-03)
 ------------------
 * Enable publishing of GPS heading and meta

--- a/av_gps_launch/CHANGELOG.rst
+++ b/av_gps_launch/CHANGELOG.rst
@@ -8,7 +8,7 @@ Forthcoming
   - Set use_binary_message to false to avoid ASCII parsing warnings
   - Set publish_imu_messages to false as IMU is not integrated on
   current GNSS
-  - Define wayt_for_sync to wait for both BESTPOS and BESTVEL messages
+  - Define wait_for_sync to wait for both BESTPOS and BESTVEL messages
   to arrive before publishing gps_msgs/GPSFix
 * Contributors: Hector Cruz
 

--- a/av_gps_launch/config/av_gps_config.yaml
+++ b/av_gps_launch/config/av_gps_config.yaml
@@ -16,8 +16,9 @@
         publish_trackstat: True
         verbose: True
         imu_sample_rate: -1.0
-        use_binary_messages: True
-        publish_imu_messages: True
+        use_binary_messages: False
+        publish_imu_messages: False
         publish_novatel_psrdop2: True
+        wait_for_sync: True
         frame_id: gps_antenna_right_sensor
         imu_frame_id: imu


### PR DESCRIPTION
- Set `use_binary_message` to false to avoid ASCII parsing warnings
- Set `publish_imu_messages` to false as IMU is not integrated on current GNSS
- Define `wait_for_sync` to wait for both BESTPOS and BESTVEL messages to arrive before publishing gps_msgs/GPSFix